### PR TITLE
Set the value of the CodeMirror on first load

### DIFF
--- a/src/Reflex/CodeMirror.hs
+++ b/src/Reflex/CodeMirror.hs
@@ -10,6 +10,7 @@ module Reflex.CodeMirror ( module Reflex.CodeMirror.Types
                          ) where
 import "base"             Control.Monad.IO.Class (MonadIO, liftIO)
 import "base"             Data.IORef (IORef, newIORef, writeIORef, readIORef)
+import "lens"             Control.Lens ((^.))
 import "text"             Data.Text (Text)
 import "jsaddle"          Language.Javascript.JSaddle -- (JSVal) --  GHCJS.Types (JSVal)
 import "reflex-dom"       Reflex.Dom hiding (setValue)
@@ -97,12 +98,15 @@ codemirror configuration textE scrollToE = do
                     -> JSM ()
         onFirstTime element_ ref trigger configuration_ mText mScrollTo = do
             ref_ <- fromTextArea element_ configuration_
+            case configuration_ ^. configuration_value of
+                Nothing -> pure ()
+                Just startTxt -> setValueAndRefresh ref_ startTxt
             liftIO $ writeIORef ref (Just ref_)
             registerOnChange ref_
                              (onChangeCallback trigger)
             case mText of
                 Nothing -> return ()
-                Just text_ -> setValue ref_ text_
+                Just text_ -> setValueAndRefresh ref_ text_
             case mScrollTo of
                 Nothing       -> return ()
                 Just scrollTo_ -> scrollIntoView ref_ scrollTo_ 200
@@ -122,7 +126,7 @@ codemirror configuration textE scrollToE = do
         onNextTime ref_ _ mText mScrollTo = do
             case mText of
                 Nothing -> return ()
-                Just text_ -> setValue ref_ text_
+                Just text_ -> setValueAndRefresh ref_ text_
             case mScrollTo of
                 Nothing        -> return ()
                 Just scrollTo_ -> scrollIntoView ref_ scrollTo_ 200

--- a/src/Reflex/CodeMirror/FFI.hs
+++ b/src/Reflex/CodeMirror/FFI.hs
@@ -60,7 +60,7 @@ setValueAndRefresh ref text = do
         refreshMirror :: Object -> JSM ()
         refreshMirror codemirror = do
             let refreshFun = fun (\_ _ _ -> void $ codemirror ^. js0 "refresh")
-            _ <- jsg2 "setTimeout" refreshFun (1 :: Double)
+            _ <- jsg2 "setTimeout" refreshFun (100 :: Double)
             return ()
 
 scrollIntoView :: CodeMirrorRef


### PR DESCRIPTION
Hey there. There is an issue with the current code that means that sometimes the CodeMirror text doesn't show at start, due to the lack of setValue on initiation. The other issue is that refreshes weren't occurring after setValue.